### PR TITLE
lesson: #21 2-1 세션 클러스터링 with redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ repositories {
 }
 
 dependencies {
+    // 레디스 세션
+    implementation 'org.springframework.session:spring-session-data-redis'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/redis/RedisConfig.java
+++ b/src/main/java/com/example/redis/RedisConfig.java
@@ -28,4 +28,10 @@ public class RedisConfig {
 		template.setValueSerializer(new GenericToStringSerializer<>(Integer.class)); // 값이 무조건 정수일 때 사용
 		return template;
 	}
+
+	@Bean
+	public RedisSerializer<Object> springSessionDefaultRedisSerializer() {
+		return RedisSerializer.java();
+		// return RedisSerializer.json(); // Security를 사용하면 Context의 생성자가 없어서 에러가 날 수 있다.
+	}
 }


### PR DESCRIPTION
- close #21 
- JSESSIONID대신 SESSION사용 
<img width="792" height="240" alt="스크린샷 2025-10-31 오후 11 38 01" src="https://github.com/user-attachments/assets/1265369d-9e3f-451d-8355-0bdcf92047af" />

- 직렬화를 위한 Config설정필요
<img width="973" height="347" alt="스크린샷 2025-10-31 오후 11 43 24" src="https://github.com/user-attachments/assets/3a972221-5cc6-4047-906d-e98721cb9641" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* Redis 기반 HTTP 세션 관리 지원이 추가되었습니다. 이제 애플리케이션에서 Redis를 통한 분산 세션 저장소를 활용할 수 있으며, 세션 데이터의 저장 및 조회가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->